### PR TITLE
feat: Create a tunnel deployent in the cluster when defining a tunnel

### DIFF
--- a/CloudflareOperator/Entities/Tunnel.cs
+++ b/CloudflareOperator/Entities/Tunnel.cs
@@ -33,6 +33,8 @@ public enum TunnelState
 {
     Uninitialized,
     Created,
+    Deploying,
     Done,
-    MissingDns
+    MissingDns,
+    MissingTunnel
 }

--- a/CloudflareOperator/Program.cs
+++ b/CloudflareOperator/Program.cs
@@ -14,8 +14,6 @@ builder.Services.AddSerilog((ctx, configuration) =>
         .ReadFrom.Configuration(builder.Configuration);
 });
 
-builder.Logging.SetMinimumLevel(LogLevel.Trace);
-
 builder.Services
     .AddRefitClient<ICloudflareClient>()
     .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://api.cloudflare.com/client/v4"));
@@ -24,6 +22,8 @@ builder.Services
     .AddHostedService<RemoteTunnelWatcher>()
     .AddHostedService<TunnelSecretWatcher>()
     .AddHostedService<TunnelDnsWatcher>()
+    .AddHostedService<TunnelDeploymentWatcher>()
+    .AddSingleton<TunnelDeploymentService>()
     .AddSingleton<ApiTokenService>()
     .AddSingleton<DnsService>()
     .AddMemoryCache()

--- a/CloudflareOperator/Services/TunnelDeploymentService.cs
+++ b/CloudflareOperator/Services/TunnelDeploymentService.cs
@@ -1,0 +1,115 @@
+using CloudflareOperator.Entities;
+using k8s;
+using k8s.Models;
+using KubeOps.Abstractions.Rbac;
+using KubeOps.KubernetesClient;
+
+namespace CloudflareOperator.Services;
+
+[EntityRbac(typeof(V1Tunnel), Verbs = RbacVerb.List)]
+[EntityRbac(typeof(V1Deployment), Verbs = RbacVerb.Create | RbacVerb.Watch | RbacVerb.Delete)]
+public sealed class TunnelDeploymentService(IKubernetesClient client)
+{
+    public enum TunnelKind
+    {
+        Access,
+        Tunnel
+    }
+
+    private static readonly Dictionary<string, string> Labels = new()
+    {
+        ["strive.io/operator"] = "cloudflared"
+    };
+
+    public async Task Deploy<T>(
+        T owner,
+        TunnelKind kind,
+        string @namespace,
+        string image,
+        V1SecretKeySelector connectionSecret,
+        CancellationToken cancellationToken)
+        where T : IKubernetesObject, IMetadata<V1ObjectMeta>
+    {
+        await client.SaveAsync(
+            new V1Deployment
+            {
+                Kind = V1Deployment.KubeKind,
+                ApiVersion = $"{V1Deployment.KubeGroup}/{V1Deployment.KubeApiVersion}",
+                Metadata = new V1ObjectMeta
+                {
+                    Name = owner.Name(),
+                    NamespaceProperty = @namespace,
+                    OwnerReferences = [owner.CreateOwnerReference()],
+                    Labels = Labels
+                },
+                Spec = new V1DeploymentSpec
+                {
+                    Selector = new V1LabelSelector
+                    {
+                        MatchLabels = Labels
+                    },
+                    Template = new V1PodTemplateSpec
+                    {
+                        Metadata = new V1ObjectMeta
+                        {
+                            Labels = Labels
+                        },
+                        Spec = new V1PodSpec
+                        {
+                            Containers = [CreatePodSpec(kind, image, connectionSecret)]
+                        }
+                    }
+                }
+            },
+            cancellationToken);
+    }
+
+    private static V1Container CreatePodSpec(TunnelKind kind, string image, V1SecretKeySelector connectionSecret)
+    {
+        return kind switch
+        {
+            TunnelKind.Tunnel => new V1Container
+            {
+                Name = "tunnel",
+                Image = image,
+                Args = ["tunnel", "--no-autoupdate", "run", "--token=$(CLOUDFLARE_TOKEN)"],
+                Env =
+                [
+                    new V1EnvVar
+                    {
+                        Name = "CLOUDFLARE_TOKEN",
+                        ValueFrom = new V1EnvVarSource
+                        {
+                            SecretKeyRef = connectionSecret
+                        }
+                    }
+                ]
+            },
+            _ => throw new InvalidOperationException($"Unknown Tunnel kind: {kind}")
+        };
+    }
+
+    public async Task Delete<T>(T owner, string @namespace, CancellationToken cancellationToken)
+        where T : IKubernetesObject, IMetadata<V1ObjectMeta>
+    {
+        await client.DeleteAsync(new V1Deployment
+            {
+                Kind = V1Deployment.KubeKind,
+                ApiVersion = $"{V1Deployment.KubeGroup}/{V1Deployment.KubeApiVersion}",
+                Metadata = new V1ObjectMeta
+                {
+                    Name = owner.Name(),
+                    NamespaceProperty = @namespace,
+                    OwnerReferences = [owner.CreateOwnerReference()],
+                    Labels = Labels
+                }
+            },
+            cancellationToken);
+    }
+
+    public Task<V1Deployment?> Get<T>(T owner, string @namespace, CancellationToken cancellationToken)
+        where T : IKubernetesObject, IMetadata<V1ObjectMeta>
+    {
+        return client.GetAsync<V1Deployment>(owner.Name(), @namespace, cancellationToken);
+    }
+}

--- a/CloudflareOperator/Watchers/TunnelDeploymentWatcher.cs
+++ b/CloudflareOperator/Watchers/TunnelDeploymentWatcher.cs
@@ -1,0 +1,42 @@
+using CloudflareOperator.Entities;
+using CloudflareOperator.Services;
+using k8s.Models;
+using KubeOps.Abstractions.Queue;
+using KubeOps.KubernetesClient;
+
+namespace CloudflareOperator.Watchers;
+
+public sealed class TunnelDeploymentWatcher(
+    ILogger<TunnelDeploymentWatcher> logger,
+    IKubernetesClient client,
+    TunnelDeploymentService tunnelDeploymentService,
+    EntityRequeue<V1Tunnel> requeue
+) : WatcherBase
+{
+    protected override async Task Watch(CancellationToken cancellationToken)
+    {
+        foreach (var tunnel in await GetTunnels(cancellationToken))
+        {
+            if (tunnel.Status.Status != TunnelState.Done)
+                continue;
+
+            var deployment = await tunnelDeploymentService.Get(tunnel, tunnel.Spec.ResourceNamespace, cancellationToken);
+
+            if (deployment is not null && deployment.IsOwnedBy(tunnel))
+                continue;
+
+            logger.LogInformation("Tunnel deployment {Name} missing, recreating", tunnel.Name());
+
+            tunnel.Status.Status = TunnelState.MissingTunnel;
+            var t = await client.UpdateStatusAsync(tunnel, cancellationToken);
+            requeue(t, TimeSpan.FromMilliseconds(10));
+        }
+
+        await Task.Delay(TimeSpan.FromSeconds(10), cancellationToken);
+    }
+
+    private Task<IList<V1Tunnel>> GetTunnels(CancellationToken cancellationToken)
+    {
+        return client.ListAsync<V1Tunnel>(cancellationToken: cancellationToken);
+    }
+}


### PR DESCRIPTION
When we create a tunnel definition in the cluster we will also deploy a tunnel using the secret that we created.

This is not an access tunnel as that will be created with a separate CRD as they are likely to be deployed in a separate cluster.