### PR TITLE
feat: Allow for attaching access policies to applications

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,7 +20,7 @@ jobs:
           dotnet-version: 9.0.x
       - name: Restore dependencies
         run: dotnet restore
-      - name: Restore toold
+      - name: Restore tools
         run: dotnet tool restore
       - name: Build
         run: dotnet build --no-restore

--- a/CloudflareOperator/Clients/ICloudflareClient.cs
+++ b/CloudflareOperator/Clients/ICloudflareClient.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+using System.Text.Json.Serialization;
 using CloudflareOperator.Clients.Models;
 using Refit;
 
@@ -16,6 +18,19 @@ public interface ICloudflareClient
         CancellationToken cancellationToken = default);
 
     #endregion Zone
+
+    #region Policy
+
+    // https://developers.cloudflare.com/api/resources/zero_trust/subresources/access/subresources/policies/
+
+    [Get("/accounts/{AccountId}/access/policies")]
+    Task<IApiResponse<ResponseEnvelope<ImmutableArray<Policy>?>>> GetPolicies(
+        [Header("Authorization")] string authToken,
+        [AliasAs("AccountId")] string accountId,
+        [Query] [AliasAs("page")] int page,
+        CancellationToken cancellationToken = default);
+
+    #endregion Policy
 
     #region Application
 
@@ -53,7 +68,6 @@ public interface ICloudflareClient
     #region Dns
 
     // https://developers.cloudflare.com/api/resources/dns/subresources/records/
-
     [Post("/zones/{ZoneId}/dns_records")]
     Task CreateDnsRecord(
         [Header("Authorization")] string authToken,
@@ -126,6 +140,10 @@ public interface ICloudflareClient
 
     #endregion
 }
+
+public sealed record Policy(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("name")] string Name);
 
 public static class IApiResponseExtensions
 {

--- a/CloudflareOperator/Clients/ICloudflareClient.cs
+++ b/CloudflareOperator/Clients/ICloudflareClient.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using System.Text.Json.Serialization;
 using CloudflareOperator.Clients.Models;
 using Refit;
 
@@ -68,6 +67,7 @@ public interface ICloudflareClient
     #region Dns
 
     // https://developers.cloudflare.com/api/resources/dns/subresources/records/
+
     [Post("/zones/{ZoneId}/dns_records")]
     Task CreateDnsRecord(
         [Header("Authorization")] string authToken,
@@ -140,10 +140,6 @@ public interface ICloudflareClient
 
     #endregion
 }
-
-public sealed record Policy(
-    [property: JsonPropertyName("id")] string Id,
-    [property: JsonPropertyName("name")] string Name);
 
 public static class IApiResponseExtensions
 {

--- a/CloudflareOperator/Clients/ICloudflareClient.cs
+++ b/CloudflareOperator/Clients/ICloudflareClient.cs
@@ -32,6 +32,8 @@ public interface ICloudflareClient
     #endregion Policy
 
     #region Application
+    
+    // https://developers.cloudflare.com/api/resources/zero_trust/subresources/access/subresources/applications/
 
     [Post("/accounts/{AccountId}/access/apps")]
     Task<IApiResponse<ResponseEnvelope<Application>>> CreateApplication(

--- a/CloudflareOperator/Clients/Models/Application.cs
+++ b/CloudflareOperator/Clients/Models/Application.cs
@@ -14,4 +14,5 @@ public sealed record Application(
 
     [JsonPropertyName("logo_url")] public string? LogoUrl { get; init; }
     [JsonPropertyName("destinations")] public ImmutableArray<ApplicationDestination>? Destinations { get; init; }
+    [JsonPropertyName("policies")] public ImmutableArray<ApplicationAccessPolicy>? Policies { get; init; }
 }

--- a/CloudflareOperator/Clients/Models/ApplicationAccessPolicy.cs
+++ b/CloudflareOperator/Clients/Models/ApplicationAccessPolicy.cs
@@ -1,0 +1,8 @@
+using System.Text.Json.Serialization;
+
+namespace CloudflareOperator.Clients.Models;
+
+public sealed record ApplicationAccessPolicy(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("precedence")]
+    int Precedence);

--- a/CloudflareOperator/Clients/Models/CreateApplication.cs
+++ b/CloudflareOperator/Clients/Models/CreateApplication.cs
@@ -14,4 +14,5 @@ public sealed record CreateApplication(
 
     [JsonPropertyName("logo_url")] public string? LogoUrl { get; init; }
     [JsonPropertyName("destinations")] public ImmutableArray<ApplicationDestination>? Destinations { get; init; }
+    [JsonPropertyName("policies")] public ImmutableArray<string>? Policies { get; init; }
 }

--- a/CloudflareOperator/Clients/Models/Policy.cs
+++ b/CloudflareOperator/Clients/Models/Policy.cs
@@ -1,0 +1,7 @@
+using System.Text.Json.Serialization;
+
+namespace CloudflareOperator.Clients;
+
+public sealed record Policy(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("name")] string Name);

--- a/CloudflareOperator/CloudflareOperator.csproj
+++ b/CloudflareOperator/CloudflareOperator.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>

--- a/CloudflareOperator/CloudflareOperator.csproj
+++ b/CloudflareOperator/CloudflareOperator.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <OutputType>Exe</OutputType>
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -25,12 +24,6 @@
         <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0"/>
         <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0"/>
         <PackageReference Include="System.Text.Json" Version="9.0.3"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <None Update="appsettings.json">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </None>
     </ItemGroup>
 
 </Project>

--- a/CloudflareOperator/Configuration/CloudflareConfiguration.cs
+++ b/CloudflareOperator/Configuration/CloudflareConfiguration.cs
@@ -1,0 +1,9 @@
+namespace CloudflareOperator.Configuration;
+
+public sealed class CloudflareConfiguration
+{
+    public const string ConfigurationSection = "Cloudflare";
+
+    public required Uri ApiUrl { get; init; }
+    public TimeSpan PolicyCacheTime { get; init; } = TimeSpan.FromMinutes(10);
+}

--- a/CloudflareOperator/Controllers/AccessApplicationController.cs
+++ b/CloudflareOperator/Controllers/AccessApplicationController.cs
@@ -10,7 +10,6 @@ using KubeOps.Abstractions.Finalizer;
 using KubeOps.Abstractions.Queue;
 using KubeOps.Abstractions.Rbac;
 using KubeOps.KubernetesClient;
-using Microsoft.Extensions.Logging;
 
 namespace CloudflareOperator.Controllers;
 

--- a/CloudflareOperator/Controllers/AccessApplicationController.cs
+++ b/CloudflareOperator/Controllers/AccessApplicationController.cs
@@ -92,8 +92,6 @@ internal sealed class AccessApplicationController(
     {
         var (primaryDomain, domains) = entity.Spec.Domains;
 
-        var policies = await policyService.GetPolicies(apiToken, entity.Spec.AccountId, entity.Spec.AccessPolicies);
-
         var application = await cloudflareClient.UpdateApplication(
                 apiToken,
                 entity.Spec.AccountId,

--- a/CloudflareOperator/Controllers/TunnelAccessController.cs
+++ b/CloudflareOperator/Controllers/TunnelAccessController.cs
@@ -3,7 +3,6 @@ using CloudflareOperator.Services;
 using k8s.Models;
 using KubeOps.Abstractions.Controller;
 using KubeOps.Abstractions.Rbac;
-using Microsoft.Extensions.Logging;
 
 namespace CloudflareOperator.Controllers;
 

--- a/CloudflareOperator/Controllers/TunnelController.cs
+++ b/CloudflareOperator/Controllers/TunnelController.cs
@@ -9,7 +9,6 @@ using KubeOps.Abstractions.Finalizer;
 using KubeOps.Abstractions.Queue;
 using KubeOps.Abstractions.Rbac;
 using KubeOps.KubernetesClient;
-using Microsoft.Extensions.Logging;
 
 namespace CloudflareOperator.Controllers;
 

--- a/CloudflareOperator/Entities/TunnelAccess.cs
+++ b/CloudflareOperator/Entities/TunnelAccess.cs
@@ -19,6 +19,3 @@ public sealed class V1TunnelAccess : CustomKubernetesEntity<V1TunnelAccess.Tunne
 
     public sealed record TunnelTarget([property: Required] string Name, [property: Required] string Host, [property: Required] int Port);
 }
-
-// b94aa7de9708967e0842e3a1a32c6bc6
-// 0bc02bd3ce9772ca70756d19f9df91dc78889ac4a1020e004cc8799a73f9cc8f

--- a/CloudflareOperator/Program.cs
+++ b/CloudflareOperator/Program.cs
@@ -1,11 +1,15 @@
 using CloudflareOperator.Clients;
+using CloudflareOperator.Configuration;
 using CloudflareOperator.Services;
 using CloudflareOperator.Watchers;
 using KubeOps.Operator;
+using Microsoft.Extensions.Options;
 using Refit;
 using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.Configure<CloudflareConfiguration>(builder.Configuration.GetSection(CloudflareConfiguration.ConfigurationSection));
 
 builder.Services.AddSerilog((ctx, configuration) =>
 {
@@ -16,7 +20,7 @@ builder.Services.AddSerilog((ctx, configuration) =>
 
 builder.Services
     .AddRefitClient<ICloudflareClient>()
-    .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://api.cloudflare.com/client/v4"));
+    .ConfigureHttpClient((ctx, c) => c.BaseAddress = ctx.GetRequiredService<IOptions<CloudflareConfiguration>>().Value.ApiUrl);
 
 builder.Services
     .AddHostedService<RemoteTunnelWatcher>()
@@ -34,6 +38,6 @@ builder.Services
     .AddKubernetesOperator()
     .RegisterComponents();
 
-using var app = builder.Build();
+await using var app = builder.Build();
 
 await app.RunAsync();

--- a/CloudflareOperator/Program.cs
+++ b/CloudflareOperator/Program.cs
@@ -2,8 +2,6 @@ using CloudflareOperator.Clients;
 using CloudflareOperator.Services;
 using CloudflareOperator.Watchers;
 using KubeOps.Operator;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Refit;
 using Serilog;
 

--- a/CloudflareOperator/Program.cs
+++ b/CloudflareOperator/Program.cs
@@ -5,7 +5,7 @@ using KubeOps.Operator;
 using Refit;
 using Serilog;
 
-var builder = Host.CreateApplicationBuilder(args);
+var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddSerilog((ctx, configuration) =>
 {

--- a/CloudflareOperator/Program.cs
+++ b/CloudflareOperator/Program.cs
@@ -31,6 +31,7 @@ builder.Services
     .AddSingleton<TunnelDeploymentService>()
     .AddSingleton<ApiTokenService>()
     .AddSingleton<DnsService>()
+    .AddSingleton<PolicyService>()
     .AddMemoryCache()
     .AddKubernetesOperator()
     .RegisterComponents();

--- a/CloudflareOperator/Services/ApiTokenService.cs
+++ b/CloudflareOperator/Services/ApiTokenService.cs
@@ -3,7 +3,6 @@ using CloudflareOperator.Entities;
 using k8s.Models;
 using KubeOps.Abstractions.Rbac;
 using KubeOps.KubernetesClient;
-using Microsoft.Extensions.Logging;
 
 namespace CloudflareOperator.Services;
 

--- a/CloudflareOperator/Services/DnsService.cs
+++ b/CloudflareOperator/Services/DnsService.cs
@@ -2,7 +2,6 @@ using CloudflareOperator.Clients;
 using CloudflareOperator.Clients.Models;
 using CloudflareOperator.Entities;
 using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Logging;
 
 namespace CloudflareOperator.Services;
 

--- a/CloudflareOperator/Services/DnsService.cs
+++ b/CloudflareOperator/Services/DnsService.cs
@@ -143,7 +143,7 @@ internal sealed class DnsService(
 
             entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromDays(1);
 
-            return (zones.Result ?? []).FirstOrDefault(z => Equals(domain, StringComparison.InvariantCultureIgnoreCase))?.Id ?? string.Empty;
+            return (zones.Result ?? []).FirstOrDefault(z => string.Equals(z.Name, domain, StringComparison.InvariantCultureIgnoreCase))?.Id ?? string.Empty;
         })!;
     }
 

--- a/CloudflareOperator/Services/PolicyService.cs
+++ b/CloudflareOperator/Services/PolicyService.cs
@@ -1,0 +1,53 @@
+using System.Collections.Immutable;
+using CloudflareOperator.Clients;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace CloudflareOperator.Services;
+
+internal sealed class PolicyService(
+    ICloudflareClient cloudflareClient,
+    IMemoryCache cache
+)
+{
+    public async Task<bool> HasPolicy(string authToken, string accountId, string policyName)
+    {
+        var policies = await GetPolicies(authToken, accountId);
+
+        return policies.ContainsKey(policyName);
+    }
+
+    public async Task<ImmutableArray<string>> GetPolicies(string authToken, string accountId, ImmutableArray<string> policyNames)
+    {
+        if (policyNames.Length == 0)
+            return [];
+
+        var polices = await GetPolicies(authToken, accountId);
+
+        return [..policyNames.Select(p => polices[p])];
+    }
+
+    private Task<ImmutableDictionary<string, string>> GetPolicies(string authToken, string accountId)
+    {
+        return cache.GetOrCreateAsync<ImmutableDictionary<string, string>>("policies", async entity =>
+        {
+            var policies = new Dictionary<string, string>();
+            var page = 1;
+
+            while (true)
+            {
+                var result = await cloudflareClient.GetPolicies(authToken, accountId, page).GetResponseContent();
+                page++;
+
+                if (result is not { Success: true, Result: not null })
+                    break;
+
+                foreach (var policy in result.Result)
+                    policies[policy.Name] = policy.Id;
+            }
+
+            entity.SetAbsoluteExpiration(TimeSpan.FromMinutes(10));
+
+            return policies.ToImmutableDictionary();
+        })!;
+    }
+}

--- a/CloudflareOperator/Watchers/RemoteAccessApplicationWatcher.cs
+++ b/CloudflareOperator/Watchers/RemoteAccessApplicationWatcher.cs
@@ -6,7 +6,6 @@ using k8s.Models;
 using KubeOps.Abstractions.Queue;
 using KubeOps.Abstractions.Rbac;
 using KubeOps.KubernetesClient;
-using Microsoft.Extensions.Logging;
 
 namespace CloudflareOperator.Watchers;
 

--- a/CloudflareOperator/Watchers/RemoteAccessApplicationWatcher.cs
+++ b/CloudflareOperator/Watchers/RemoteAccessApplicationWatcher.cs
@@ -76,7 +76,7 @@ internal sealed class RemoteAccessApplicationWatcher(
 
         var policies = await policyService.GetPolicies(apiToken, entity.Spec.AccountId, entity.Spec.AccessPolicies);
 
-        return policies.SequenceEqual(application.Policies.Value.Select(x => x.Id));
+        return policies.SequenceEqual(application.Policies.Value.OrderBy(x => x.Precedence).Select(x => x.Id));
     }
 
     private Task<IList<V1AccessApplication>> ListApplications(CancellationToken cancellationToken)

--- a/CloudflareOperator/Watchers/RemoteTunnelWatcher.cs
+++ b/CloudflareOperator/Watchers/RemoteTunnelWatcher.cs
@@ -5,7 +5,6 @@ using k8s.Models;
 using KubeOps.Abstractions.Queue;
 using KubeOps.Abstractions.Rbac;
 using KubeOps.KubernetesClient;
-using Microsoft.Extensions.Logging;
 
 namespace CloudflareOperator.Watchers;
 

--- a/CloudflareOperator/Watchers/TunnelDeploymentWatcher.cs
+++ b/CloudflareOperator/Watchers/TunnelDeploymentWatcher.cs
@@ -4,7 +4,6 @@ using k8s;
 using k8s.Models;
 using KubeOps.Abstractions.Queue;
 using KubeOps.KubernetesClient;
-using Microsoft.Extensions.Logging;
 
 namespace CloudflareOperator.Watchers;
 

--- a/CloudflareOperator/Watchers/TunnelDnsWatcher.cs
+++ b/CloudflareOperator/Watchers/TunnelDnsWatcher.cs
@@ -4,7 +4,6 @@ using k8s.Models;
 using KubeOps.Abstractions.Queue;
 using KubeOps.Abstractions.Rbac;
 using KubeOps.KubernetesClient;
-using Microsoft.Extensions.Logging;
 
 namespace CloudflareOperator.Watchers;
 

--- a/CloudflareOperator/Watchers/TunnelSecretWatcher.cs
+++ b/CloudflareOperator/Watchers/TunnelSecretWatcher.cs
@@ -4,7 +4,6 @@ using k8s.Models;
 using KubeOps.Abstractions.Queue;
 using KubeOps.Abstractions.Rbac;
 using KubeOps.KubernetesClient;
-using Microsoft.Extensions.Logging;
 
 namespace CloudflareOperator.Watchers;
 

--- a/CloudflareOperator/Watchers/WatcherBase.cs
+++ b/CloudflareOperator/Watchers/WatcherBase.cs
@@ -1,5 +1,3 @@
-using Microsoft.Extensions.Hosting;
-
 namespace CloudflareOperator.Watchers;
 
 public abstract class WatcherBase : IHostedService

--- a/CloudflareOperator/Webhooks/AccessApplicationValidationWebhook.cs
+++ b/CloudflareOperator/Webhooks/AccessApplicationValidationWebhook.cs
@@ -1,0 +1,46 @@
+using System.Collections.Immutable;
+using CloudflareOperator.Entities;
+using CloudflareOperator.Services;
+using KubeOps.Operator.Web.Webhooks.Admission.Validation;
+
+namespace CloudflareOperator.Webhooks;
+
+[ValidationWebhook(typeof(V1AccessApplication))]
+internal sealed class AccessApplicationValidationWebhook(
+    ApiTokenService apiTokenService,
+    PolicyService policyService
+) : ValidationWebhook<V1AccessApplication>
+{
+    public override Task<ValidationResult> CreateAsync(V1AccessApplication entity, bool dryRun, CancellationToken cancellationToken)
+    {
+        return Validate(entity, cancellationToken);
+    }
+
+    public override Task<ValidationResult> UpdateAsync(V1AccessApplication oldEntity, V1AccessApplication newEntity, bool dryRun, CancellationToken cancellationToken)
+    {
+        return Validate(newEntity, cancellationToken);
+    }
+
+    private async Task<ValidationResult> Validate(V1AccessApplication entity, CancellationToken cancellationToken)
+    {
+        var (success, apiToken) = await apiTokenService.TryGetApiToken(entity.Spec.ApiToken, cancellationToken);
+
+        if (!success)
+            return Fail("Could not find access token");
+
+        if (!await AllPoliciesExist(apiToken, entity.Spec.AccountId, entity.Spec.AccessPolicies))
+            return Fail("Access polices do not exist");
+
+        return Success();
+    }
+
+    private async Task<bool> AllPoliciesExist(string authToken, string accountId, ImmutableArray<string> policies)
+    {
+        if (policies.Length == 0)
+            return true;
+
+        var result = await Task.WhenAll(policies.Select(p => policyService.HasPolicy(authToken, accountId, p)));
+
+        return result.All(x => x);
+    }
+}

--- a/CloudflareOperator/Webhooks/TunnelAccessValidationWebhook.cs
+++ b/CloudflareOperator/Webhooks/TunnelAccessValidationWebhook.cs
@@ -25,7 +25,7 @@ public sealed class TunnelAccessValidationWebhook(
     private async Task<ValidationResult> Validate(V1TunnelAccess entity, CancellationToken cancellationToken)
     {
         if (!await SecretExists(entity.Namespace(), entity.Spec.AccessTokenRef, cancellationToken) || !await SecretExists(entity.Namespace(), entity.Spec.SecretAccessTokenRef, cancellationToken))
-            return Fail("Could not find access screret");
+            return Fail("Could not find access secret");
 
         if (entity.Spec.Targets.Length <= 0)
             return Fail("At least one target is required");

--- a/CloudflareOperator/appsettings.json
+++ b/CloudflareOperator/appsettings.json
@@ -1,10 +1,4 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  },
   "AllowedHosts": "*",
   "Serilog": {
     "Using": [
@@ -30,7 +24,7 @@
       }
     ],
     "MinimumLevel": {
-      "Default": "Debug",
+      "Default": "Information",
       "Override": {
         "Microsoft": "Warning",
         "Microsoft.AspNetCore": "Warning",
@@ -38,5 +32,9 @@
         "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
       }
     }
+  },
+  "Cloudflare": {
+    "ApiUrl": "https://api.cloudflare.com/client/v4",
+    "PolicyCacheTime": "00:10:00"
   }
 }


### PR DESCRIPTION
Allows us to attach access polices to applications.

The policy must already exist without cloudflare and modifications to the applications policy through the UI will be replaced to respect the expected result from the application definition.

The policy precedence will be defined as the order the polices appear in the resource.